### PR TITLE
Add simple novel editor

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,86 @@
+<!DOCTYPE html>
+<html lang="ja">
+<head>
+<meta charset="UTF-8">
+<title>ノベルエディター</title>
+<style>
+body {
+  margin: 0;
+  padding: 0;
+  height: 100vh;
+  display: flex;
+  flex-direction: column;
+  font-family: sans-serif;
+}
+header {
+  background: #333;
+  color: white;
+  padding: 0.5rem;
+  display: flex;
+  align-items: center;
+}
+header input {
+  margin-right: 1rem;
+  flex: 1;
+  padding: 0.3rem;
+}
+header button {
+  margin-right: 0.5rem;
+  padding: 0.3rem 0.6rem;
+}
+textarea {
+  flex: 1;
+  width: 100%;
+  padding: 1rem;
+  box-sizing: border-box;
+  font-size: 1rem;
+  line-height: 1.5;
+  resize: none;
+}
+</style>
+</head>
+<body>
+<header>
+  <input id="title" placeholder="タイトル" />
+  <button id="save">保存</button>
+  <button id="load">読み込み</button>
+  <button id="export">ダウンロード</button>
+</header>
+<textarea id="editor" placeholder="本文を入力してください..."></textarea>
+<script>
+const titleInput = document.getElementById('title');
+const editor = document.getElementById('editor');
+const saveBtn = document.getElementById('save');
+const loadBtn = document.getElementById('load');
+const exportBtn = document.getElementById('export');
+
+saveBtn.addEventListener('click', () => {
+  localStorage.setItem('novel_title', titleInput.value);
+  localStorage.setItem('novel_text', editor.value);
+  alert('保存しました');
+});
+
+loadBtn.addEventListener('click', () => {
+  titleInput.value = localStorage.getItem('novel_title') || '';
+  editor.value = localStorage.getItem('novel_text') || '';
+  alert('読み込みました');
+});
+
+exportBtn.addEventListener('click', () => {
+  const title = titleInput.value || 'novel';
+  const blob = new Blob([editor.value], {type: 'text/plain'});
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement('a');
+  a.href = url;
+  a.download = title + '.txt';
+  a.click();
+  URL.revokeObjectURL(url);
+});
+
+window.addEventListener('load', () => {
+  titleInput.value = localStorage.getItem('novel_title') || '';
+  editor.value = localStorage.getItem('novel_text') || '';
+});
+</script>
+</body>
+</html>


### PR DESCRIPTION
## Summary
- build a single page web novel editor
- allow saving/loading from local storage
- export novel text to a download file

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_68402129d7e88322b9b1cce7fcddbf81